### PR TITLE
Document recent additions and add BSP support page

### DIFF
--- a/docs/Modding/mounts.md
+++ b/docs/Modding/mounts.md
@@ -25,6 +25,7 @@ Example of the format is below:
 
 		"portal2" // mod_folder, folder inside of the given AppID (Portal 2)'s folder. In this case, <portal 2 install>\portal2\
 		{
+			"mountmoddir" "0"
 			"vpk"	"pak01_dir" // mounts VPK: <Portal 2 install>\portal2\pak01_dir.vpk
 			"dir"	"custom" // mounts folder: <Portal 2 install>\portal2\custom\
 		}
@@ -83,3 +84,11 @@ It is ideal to mount each of the `<filename>_dir.vpk` (VPK directory) files here
 This string value is a subfolder inside of `mod_folder` that is mounted.
 
 For older games such as TF2 and CS:S, you may want to mount the `download` or `custom` folders here alongside the VPKs.  
+
+#### `mountmoddir` property
+
+This is an integer, 0 or 1, that determines if the `mod_folder` gets added as search path.
+
+The default is 1 if omitted, which causes all maps/textures/sounds/etc. shipped as loose files with the mod to be mounted and appear in-game. It will only be considered for searches after the VPKs and subfolders specified in this block.
+
+Setting it to 0 instead will still mount all contained `vpk` and `dir` blocks but **not** the `mod_folder`.

--- a/docs/Reference/bspsupport.md
+++ b/docs/Reference/bspsupport.md
@@ -1,0 +1,28 @@
+---
+layout: default
+title: BSP Support
+parent: Reference
+---
+
+# BSP Support
+
+This is an overview of which versions of the BSP map file format the Chaos engine can launch.
+Some formats can be converted to a supported version by manipulating the raw binary data, while others would need decompilation with an appropriate tool,
+which might break certain properties without manual intervention.
+
+Furthermore, it's not guaranteed that every format that is listed as supported works 100% since there might still be game-specific incompatiblities. 
+
+Source 2 is not supported at all as its formats aren't documented and it no longer uses binary space partition.
+
+For more details, see [the Valve Developer Wiki page](https://developer.valvesoftware.com/wiki/Source_BSP_File_Format).
+
+Engine|Version(s)|Games|Supported|Planned|Details|
+|---|---|---|---|---|---|
+IdTech|Any|Quake 1/2/3|No|No|Too different from modern Source|
+GoldSrc|Any|Half-Life, Team Fortress Classic, CS 1.6|No|No|Too different. It's possible to decompile, and then recompile for Source|
+Source|≤18|Vampire: the Masquerade, very old HL2|Untested|No|Might work with manual binary editing|
+Source|19-20|HL2, TF2, CSS|Yes|-|Fully supported|
+Source|20|GMod, L4D, Black Mesa|Yes|-|Map loads, parts might be broken due to missing shaders/scripting, etc.|
+Source|21|Portal 2, CSGO, Alien Swarm, any Chaos VBSP compiled maps|Yes|-|Natively supported, preferred for any Chaos game|
+Source|21|Left 4 Dead 2|No|Probably not|Can be fixed by swapping entries in lump headers around, see link above|
+Source|≥22|pre-Reborn Dota 2, Contagion, any Respawn Source games|No|No|Too many undocumented differences to make it worth|

--- a/docs/Reference/launchoptions.md
+++ b/docs/Reference/launchoptions.md
@@ -12,6 +12,8 @@ for a full list of launch options, please see [the Valve Developer Wiki page](ht
 |Option|Description|
 |---|---|
 |-mountmod <path>|Specifies the mod to launch the game with. Must be an absolute path|
+|-nogamemount|Do not mount any games/mods specified in the gameinfo mounts block or mounts.kv|
+|-nocustommount|Do not mount any folders specified in gameinfo which contain wildcards (* or ?), usually "custom" folders|
 |-legacyui|Launches the game with the old VGUI GameUI|
 |-dev|Developer mode|
 |-dx11|Launch game with DirectX 11 shaderapi (On Linux, this will launch dx11 with dxvk)|


### PR DESCRIPTION
Closes #5 

- Documents which BSP versions we actively support
- Adds mounting launch options
- Documents mountmoddir